### PR TITLE
Fix Windows GNU static runtime linking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,18 @@ jobs:
         with:
           command: build
           args: --verbose ${{ matrix.os == 'windows-2022' && '--release' || '' }} --target ${{ matrix.target }}
+
+      - name: Verify static MinGW runtime linking
+        if: contains(matrix.target, 'windows-gnu')
+        shell: bash
+        run: |
+          cargo build --verbose --target "${{ matrix.target }}" --features static-cpp-runtime
+          imports="$(x86_64-w64-mingw32-objdump -p "target/${{ matrix.target }}/debug/ocr_rs.dll" | sed -n 's/.*DLL Name: //p')"
+          echo "$imports"
+          if grep -Eiq 'libstdc\+\+|libgcc|libwinpthread|libssp|libgomp|libatomic|libquadmath' <<<"$imports"; then
+            echo "Static runtime build still imports a MinGW runtime DLL"
+            exit 1
+          fi
       
       - name: Run tests
         if: contains(matrix.target, 'x86_64') && !contains(matrix.target, 'windows-gnu')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ mnn-dynamic = []
 # 使用预编译的 MNN 静态库，需设置 MNN_LIB_DIR 和 MNN_INCLUDE_DIR 环境变量
 mnn-static = []
 
+# 在 Windows GNU 上静态链接 MinGW C++/GCC/pthread 运行时，避免分发 MinGW DLL
+static-cpp-runtime = []
+
 # 可选特性
 async = ["tokio", "futures"]
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,15 @@ assert!(Backend::Metal.is_available());
 
 Engine creation returns `MnnError::BackendUnavailable` when the requested backend was not registered instead of silently falling back to CPU.
 
-`x86_64-pc-windows-gnu` builds MNN from source and requires a MinGW C/C++ toolchain. NVIDIA's Windows CUDA toolchain requires MSVC; use `x86_64-pc-windows-msvc` for source-built CUDA, or provide a compatible MNN library with `mnn-dynamic`/`mnn-static`.
+`x86_64-pc-windows-gnu` builds MNN from source and requires a MinGW C/C++ toolchain. By default, applications must distribute the matching MinGW runtime DLLs. Enable `static-cpp-runtime` to statically link libstdc++, libgcc, and winpthreads so the resulting binary does not depend on MinGW runtime DLLs:
+
+```bash
+cargo build --release --target x86_64-pc-windows-gnu --features static-cpp-runtime
+```
+
+NVIDIA's Windows CUDA toolchain requires MSVC; use `x86_64-pc-windows-msvc` for source-built CUDA, or provide a compatible MNN library with `mnn-dynamic`/`mnn-static`.
+
+This feature controls the runtime linked by `ocr-rs`; a user-supplied DLL selected with `mnn-dynamic` may still have its own MinGW runtime dependencies.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,9 @@ use std::{env, fs};
 mod build_support;
 
 use build_support::{
-    cpp_runtime_library, cuda_side_library_plan, prebuilt_asset_name, select_link_mode,
-    should_link_mnn_whole_archive, uses_msvc_flags, BuildFeatures, MnnLinkMode, TargetInfo,
+    cpp_runtime_libraries, cuda_side_library_plan, prebuilt_asset_name, select_link_mode,
+    should_link_mnn_whole_archive, uses_msvc_flags, BuildFeatures, MnnLinkMode, NativeLinkKind,
+    TargetInfo,
 };
 
 /// MNN prebuilt version to download from GitHub releases
@@ -39,6 +40,7 @@ fn main() {
     let mnn_dynamic = env::var("CARGO_FEATURE_MNN_DYNAMIC").is_ok();
     let mnn_static = env::var("CARGO_FEATURE_MNN_STATIC").is_ok();
     let build_from_source = env::var("CARGO_FEATURE_BUILD_MNN_FROM_SOURCE").is_ok();
+    let static_cpp_runtime = env::var("CARGO_FEATURE_STATIC_CPP_RUNTIME").is_ok();
 
     let target = TargetInfo {
         os: &os,
@@ -56,6 +58,7 @@ fn main() {
         mnn_dynamic,
         mnn_static,
         build_from_source,
+        static_cpp_runtime,
     };
     let link_mode = select_link_mode(&target, &features)
         .unwrap_or_else(|error| panic!("Invalid MNN build configuration: {}", error));
@@ -744,6 +747,9 @@ fn link_libraries(
     features: &BuildFeatures,
 ) {
     let os = target.os;
+
+    emit_static_cpp_runtime_search_paths(target, features);
+
     // Add library search paths
     for dir in lib_dirs {
         println!("cargo:rustc-link-search=native={}", dir.display());
@@ -764,8 +770,11 @@ fn link_libraries(
     }
 
     // Link the C++ runtime after MNN so GNU static linking can resolve MNN's symbols.
-    if let Some(runtime) = cpp_runtime_library(target) {
-        println!("cargo:rustc-link-lib={}", runtime);
+    for library in cpp_runtime_libraries(target, features.static_cpp_runtime) {
+        match library.kind {
+            NativeLinkKind::Dynamic => println!("cargo:rustc-link-lib=dylib={}", library.name),
+            NativeLinkKind::Static => println!("cargo:rustc-link-lib=static={}", library.name),
+        }
     }
 
     // Other platform-specific system libraries
@@ -836,6 +845,52 @@ fn link_libraries(
     // Vulkan library
     if features.vulkan {
         println!("cargo:rustc-link-lib=vulkan");
+    }
+}
+
+fn emit_static_cpp_runtime_search_paths(target: &TargetInfo<'_>, features: &BuildFeatures) {
+    if target.os != "windows" || target.env != "gnu" || !features.static_cpp_runtime {
+        return;
+    }
+
+    let compiler = cc::Build::new().cpp(true).get_compiler();
+    let mut emitted = HashSet::new();
+
+    for library in cpp_runtime_libraries(target, true) {
+        if library.kind != NativeLinkKind::Static {
+            continue;
+        }
+
+        let archive_name = format!("lib{}.a", library.name);
+        let output = compiler
+            .to_command()
+            .arg(format!("-print-file-name={archive_name}"))
+            .output()
+            .unwrap_or_else(|error| {
+                panic!("Failed to query MinGW C++ compiler for {archive_name}: {error}")
+            });
+
+        if !output.status.success() {
+            panic!(
+                "MinGW C++ compiler failed to locate {archive_name}: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        let archive = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        if !archive.is_absolute() || !archive.is_file() {
+            panic!(
+                "feature `static-cpp-runtime` requires {archive_name}, but the target C++ compiler could not locate it"
+            );
+        }
+
+        let directory = archive
+            .parent()
+            .expect("MinGW runtime archive should have a parent directory")
+            .to_path_buf();
+        if emitted.insert(directory.clone()) {
+            println!("cargo:rustc-link-search=native={}", directory.display());
+        }
     }
 }
 

--- a/build_support.rs
+++ b/build_support.rs
@@ -28,6 +28,7 @@ pub struct BuildFeatures {
     pub mnn_dynamic: bool,
     pub mnn_static: bool,
     pub build_from_source: bool,
+    pub static_cpp_runtime: bool,
 }
 
 impl BuildFeatures {
@@ -176,12 +177,68 @@ pub fn uses_msvc_flags<'a>(target: &TargetInfo<'a>) -> Result<bool, BuildConfigE
     Ok(target.os == "windows" && target.env == "msvc")
 }
 
-pub fn cpp_runtime_library(target: &TargetInfo<'_>) -> Option<&'static str> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeLinkKind {
+    Dynamic,
+    Static,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeLibrary {
+    pub name: &'static str,
+    pub kind: NativeLinkKind,
+}
+
+const WINDOWS_GNU_STATIC_CPP_RUNTIME: &[NativeLibrary] = &[
+    NativeLibrary {
+        name: "stdc++",
+        kind: NativeLinkKind::Static,
+    },
+    NativeLibrary {
+        name: "gcc_eh",
+        kind: NativeLinkKind::Static,
+    },
+    NativeLibrary {
+        name: "gcc",
+        kind: NativeLinkKind::Static,
+    },
+    NativeLibrary {
+        name: "winpthread",
+        kind: NativeLinkKind::Static,
+    },
+];
+
+const WINDOWS_GNU_DYNAMIC_CPP_RUNTIME: &[NativeLibrary] = &[NativeLibrary {
+    name: "stdc++",
+    kind: NativeLinkKind::Dynamic,
+}];
+
+const LIBCXX_RUNTIME: &[NativeLibrary] = &[NativeLibrary {
+    name: "c++",
+    kind: NativeLinkKind::Dynamic,
+}];
+
+const LIBSTDCXX_RUNTIME: &[NativeLibrary] = &[NativeLibrary {
+    name: "stdc++",
+    kind: NativeLinkKind::Dynamic,
+}];
+
+const ANDROID_CPP_RUNTIME: &[NativeLibrary] = &[NativeLibrary {
+    name: "c++_static",
+    kind: NativeLinkKind::Static,
+}];
+
+pub fn cpp_runtime_libraries(
+    target: &TargetInfo<'_>,
+    static_cpp_runtime: bool,
+) -> &'static [NativeLibrary] {
     match (target.os, target.env) {
-        ("macos" | "ios", _) => Some("c++"),
-        ("linux", _) | ("windows", "gnu") => Some("stdc++"),
-        ("android", _) => Some("c++_static"),
-        _ => None,
+        ("windows", "gnu") if static_cpp_runtime => WINDOWS_GNU_STATIC_CPP_RUNTIME,
+        ("windows", "gnu") => WINDOWS_GNU_DYNAMIC_CPP_RUNTIME,
+        ("macos" | "ios", _) => LIBCXX_RUNTIME,
+        ("linux", _) => LIBSTDCXX_RUNTIME,
+        ("android", _) => ANDROID_CPP_RUNTIME,
+        _ => &[],
     }
 }
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -120,7 +120,15 @@ assert!(Backend::Metal.is_available());
 
 リンクされた MNN に要求したバックエンドが登録されていない場合、CPU に暗黙でフォールバックせず、エンジン作成時に `MnnError::BackendUnavailable` を返します。
 
-`x86_64-pc-windows-gnu` は MNN をソースからビルドするため、MinGW C/C++ ツールチェーンが必要です。NVIDIA の Windows CUDA ツールチェーンには MSVC が必要です。CUDA のソースビルドには `x86_64-pc-windows-msvc` を使うか、`mnn-dynamic`/`mnn-static` で互換 MNN を指定してください。
+`x86_64-pc-windows-gnu` は MNN をソースからビルドするため、MinGW C/C++ ツールチェーンが必要です。デフォルトでは対応する MinGW ランタイム DLL の配布が必要です。`static-cpp-runtime` を有効にすると libstdc++、libgcc、winpthreads が静的リンクされ、生成されたバイナリは MinGW ランタイム DLL に依存しません。
+
+```bash
+cargo build --release --target x86_64-pc-windows-gnu --features static-cpp-runtime
+```
+
+NVIDIA の Windows CUDA ツールチェーンには MSVC が必要です。CUDA のソースビルドには `x86_64-pc-windows-msvc` を使うか、`mnn-dynamic`/`mnn-static` で互換 MNN を指定してください。
+
+この feature が制御するのは `ocr-rs` 自身がリンクするランタイムです。`mnn-dynamic` で指定した DLL には、独自の MinGW ランタイム依存関係が残る場合があります。
 
 ## License
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -120,7 +120,15 @@ assert!(Backend::Metal.is_available());
 
 링크된 MNN 에 요청한 백엔드가 등록되어 있지 않으면 CPU 로 조용히 폴백하지 않고 엔진 생성 시 `MnnError::BackendUnavailable` 을 반환합니다.
 
-`x86_64-pc-windows-gnu` 는 MNN 을 소스에서 빌드하므로 MinGW C/C++ 툴체인이 필요합니다. NVIDIA Windows CUDA 툴체인은 MSVC 를 요구합니다. CUDA 소스 빌드에는 `x86_64-pc-windows-msvc` 를 사용하거나 `mnn-dynamic`/`mnn-static` 으로 호환 MNN 라이브러리를 제공하세요.
+`x86_64-pc-windows-gnu` 는 MNN 을 소스에서 빌드하므로 MinGW C/C++ 툴체인이 필요합니다. 기본적으로 애플리케이션과 함께 일치하는 MinGW 런타임 DLL을 배포해야 합니다. `static-cpp-runtime` 을 활성화하면 libstdc++, libgcc 및 winpthreads를 정적으로 링크하여 생성된 바이너리의 MinGW 런타임 DLL 의존성을 제거할 수 있습니다.
+
+```bash
+cargo build --release --target x86_64-pc-windows-gnu --features static-cpp-runtime
+```
+
+NVIDIA Windows CUDA 툴체인은 MSVC 를 요구합니다. CUDA 소스 빌드에는 `x86_64-pc-windows-msvc` 를 사용하거나 `mnn-dynamic`/`mnn-static` 으로 호환 MNN 라이브러리를 제공하세요.
+
+이 feature는 `ocr-rs` 자체가 링크하는 런타임만 제어합니다. `mnn-dynamic` 으로 제공한 DLL에는 자체 MinGW 런타임 의존성이 남아 있을 수 있습니다.
 
 ## License
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -137,7 +137,15 @@ assert!(Backend::Metal.is_available());
 
 如果链接的 MNN 没有注册所请求的后端，创建引擎会返回 `MnnError::BackendUnavailable`，不再静默回退到 CPU。
 
-`x86_64-pc-windows-gnu` 会从源码构建 MNN，需要 MinGW C/C++ 工具链。NVIDIA 的 Windows CUDA 工具链要求 MSVC；源码构建 CUDA 请使用 `x86_64-pc-windows-msvc`，或通过 `mnn-dynamic`/`mnn-static` 提供兼容的 MNN 库。
+`x86_64-pc-windows-gnu` 会从源码构建 MNN，需要 MinGW C/C++ 工具链。默认情况下，应用需要携带匹配的 MinGW 运行时 DLL。启用 `static-cpp-runtime` 可静态链接 libstdc++、libgcc 和 winpthreads，使生成的二进制文件不再依赖 MinGW 运行时 DLL：
+
+```bash
+cargo build --release --target x86_64-pc-windows-gnu --features static-cpp-runtime
+```
+
+NVIDIA 的 Windows CUDA 工具链要求 MSVC；源码构建 CUDA 请使用 `x86_64-pc-windows-msvc`，或通过 `mnn-dynamic`/`mnn-static` 提供兼容的 MNN 库。
+
+该 feature 只控制 `ocr-rs` 自身链接的运行时；通过 `mnn-dynamic` 提供的第三方 DLL 仍可能带有自己的 MinGW 运行时依赖。
 
 ## License
 

--- a/tests/build_support_tests.rs
+++ b/tests/build_support_tests.rs
@@ -2,9 +2,9 @@
 mod build_support;
 
 use build_support::{
-    cpp_runtime_library, cuda_side_library_plan, prebuilt_asset_name, select_link_mode,
+    cpp_runtime_libraries, cuda_side_library_plan, prebuilt_asset_name, select_link_mode,
     should_link_mnn_whole_archive, uses_msvc_flags, BuildConfigError, BuildFeatures,
-    CudaSideLibraryPlan, MnnLinkMode, TargetInfo,
+    CudaSideLibraryPlan, MnnLinkMode, NativeLibrary, NativeLinkKind, TargetInfo,
 };
 
 fn target<'a>(os: &'a str, arch: &'a str, env: &'a str, triple: &'a str) -> TargetInfo<'a> {
@@ -249,14 +249,47 @@ fn cpu_only_and_windows_cuda_do_not_use_the_linux_cuda_side_library() {
 fn windows_gnu_explicitly_links_libstdcxx() {
     let target = target("windows", "x86_64", "gnu", "x86_64-pc-windows-gnu");
 
-    assert_eq!(cpp_runtime_library(&target), Some("stdc++"));
+    assert_eq!(
+        cpp_runtime_libraries(&target, false),
+        &[NativeLibrary {
+            name: "stdc++",
+            kind: NativeLinkKind::Dynamic,
+        }]
+    );
+}
+
+#[test]
+fn windows_gnu_can_statically_link_all_mingw_runtime_libraries() {
+    let target = target("windows", "x86_64", "gnu", "x86_64-pc-windows-gnu");
+
+    assert_eq!(
+        cpp_runtime_libraries(&target, true),
+        &[
+            NativeLibrary {
+                name: "stdc++",
+                kind: NativeLinkKind::Static,
+            },
+            NativeLibrary {
+                name: "gcc_eh",
+                kind: NativeLinkKind::Static,
+            },
+            NativeLibrary {
+                name: "gcc",
+                kind: NativeLinkKind::Static,
+            },
+            NativeLibrary {
+                name: "winpthread",
+                kind: NativeLinkKind::Static,
+            },
+        ]
+    );
 }
 
 #[test]
 fn windows_msvc_leaves_runtime_linking_to_msvc() {
     let target = target("windows", "x86_64", "msvc", "x86_64-pc-windows-msvc");
 
-    assert_eq!(cpp_runtime_library(&target), None);
+    assert!(cpp_runtime_libraries(&target, true).is_empty());
 }
 
 #[test]
@@ -265,7 +298,7 @@ fn existing_platform_cpp_runtime_choices_are_preserved() {
     let macos = target("macos", "aarch64", "", "aarch64-apple-darwin");
     let android = target("android", "aarch64", "", "aarch64-linux-android");
 
-    assert_eq!(cpp_runtime_library(&linux), Some("stdc++"));
-    assert_eq!(cpp_runtime_library(&macos), Some("c++"));
-    assert_eq!(cpp_runtime_library(&android), Some("c++_static"));
+    assert_eq!(cpp_runtime_libraries(&linux, true)[0].name, "stdc++");
+    assert_eq!(cpp_runtime_libraries(&macos, true)[0].name, "c++");
+    assert_eq!(cpp_runtime_libraries(&android, true)[0].name, "c++_static");
 }


### PR DESCRIPTION
## Summary

- add an opt-in `static-cpp-runtime` feature for Windows GNU targets
- statically link libstdc++, libgcc exception/support archives, and winpthreads
- discover MinGW archive search paths through the target C++ compiler
- document the feature and verify PE imports in CI

## Why

Fixes #46. `ocr-rs` explicitly emitted a dynamic `-lstdc++`, so downstream `-static-libstdc++` flags could not remove the `libstdc++-6.dll` dependency.

## Validation

- `cargo test --test build_support_tests` (20 passed)
- `cargo check --all-targets --features static-cpp-runtime`
- `cargo clippy --all-targets --features static-cpp-runtime -- -D warnings`
- Windows 10 MinGW build on `chenzibo@10.1.1.243`
- inspected `ocr_rs.dll` and a consumer example with `objdump`; neither imports libstdc++, libgcc, winpthread, or other common MinGW runtime DLLs
- launched the consumer example with `PATH` restricted to `C:\Windows\System32`
